### PR TITLE
Refactored macros into a separate file from core definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (WIN32)
     add_definitions(-DAYLA_PLATFORM_WINDOWS)
 elseif (APPLE)
-    add_definitions(-DAYLA_PLATFORM_APPLE)
+    add_definitions(-DAYLA_PLATFORM_MACOS)
 else ()
-    add_definitions(-DUNKNOWN_PLATFORM)
+    add_definitions(-DAYLA_PLATFORM_UNKNOWN)
 endif()
 
 

--- a/client/src/ExampleLayer.cpp
+++ b/client/src/ExampleLayer.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "ExampleLayer.h"
-#include "Ayla/Core/Core.h"
+#include "Ayla/Core/CoreDefinitions.h"
 #include "imgui.h"
 
 

--- a/src/Ayla/Client/UserSetup.cpp
+++ b/src/Ayla/Client/UserSetup.cpp
@@ -9,7 +9,7 @@ namespace Ayla::Client
 
     ClientLoop::ClientLoop()
     {
-        AY_TRACE("\n[Sholas] Client: Initializing ClientLoop");
+        AY_TRACE("[Sholas] Client: Initializing ClientLoop");
     }
 
 

--- a/src/Ayla/Client/UserSetup.h
+++ b/src/Ayla/Client/UserSetup.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Ayla/Core/Core.h"
+#include "Ayla/Core/CoreDefinitions.h"
 
 
 namespace Ayla::Client

--- a/src/Ayla/Core/Application.h
+++ b/src/Ayla/Core/Application.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "Ayla/Client/UserSetup.h"
-#include "Ayla/Core/Core.h"
+#include "Ayla/Core/CoreDefinitions.h"
 #include "Ayla/Core/Layers/LayerStack.h"
 #include "Ayla/Debug/DebugLayer.h"
 #include "Ayla/ImGui/ImGuiLayer.h"

--- a/src/Ayla/Core/CoreDefinitions.h
+++ b/src/Ayla/Core/CoreDefinitions.h
@@ -4,21 +4,28 @@
 
 #pragma once
 
-/** Preprocessor Central */
+
+/** Defines the ALYA_API for compiling Ayla into a dll/shared library file */
 #ifdef AYLA_PLATFORM_WINDOWS
     #ifdef AYLA_BUILD_SHARED_LIB
         #define AYLA_API __declspec(dllexport)        // Export
     #else
         #define AYLA_API __declspec(dllimport)        // Import
     #endif
-#elif AYLA_PLATFORM_APPLE
+#elif AYLA_PLATFORM_MACOS
     #ifdef AYLA_BUILD_SHARED_LIB
         #define AYLA_API __attribute__((visibility("default")))       // Export
     #else
         #define AYLA_API        // Import
     #endif
 #else
-    #error Something went wrong with defining Ayla API symbols (Platform not found)
+    #error Core/CoreDefinitions.h: Unsupported/Unknown Platform!
 #endif
 
 
+/** Defines the unknown platform macro if no supported platforms are defined */
+#ifndef AYLA_PLATFORM_MACOS
+    #ifndef AYLA_PLATFORM_WINDOWS
+        #define AYLA_PLATFORM_UNKNOWN
+    #endif
+#endif

--- a/src/Ayla/Core/DebugMacros.cpp
+++ b/src/Ayla/Core/DebugMacros.cpp
@@ -4,29 +4,26 @@
 
 #include "Ayla/Core/DebugMacros.h"
 
-#include <iomanip>
 
-namespace {
+namespace Ayla::Core::Macros
+{
 
     void macro_AY_TRACE(const std::string&& title)
     {
-        std::time_t time;
-        std::time(&time);
+        /** Gets the current time */
+        const std::time_t t = std::time(nullptr);
+        const std::tm* currentTime = std::localtime(&t); // Puts the information of the time into a struct that is separated into min, sec, hr, day, etc.
 
-        // TODO: Figure out a way to make the time appear nice and pretty
-        std::cout << "\n" << title; //<< std::setw(40) << "\t : " << std::ctime(&time);
+        /** Calculates the elapsed milliseconds as they were not included in the std::tm struct */
+        long long millisecondsSinceEpoch = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        long long elapsedMilliseconds = millisecondsSinceEpoch % 1000;
+
+        /** Outputs the message with the time info prefixing it */
+        std::cout << "\n[" << currentTime->tm_hour << ":" << currentTime->tm_min << ":" << currentTime->tm_sec << ":" << elapsedMilliseconds << "] " << title;
     }
 
 
-    void macro_AY_ASSERT(const bool expression, const std::string&& errorMessage)
-    {
-        if (!expression){
-            throw std::runtime_error("\n\n" + errorMessage);
-        }
-    }
-
-
-    void macro_AY_ASSERT_SS(const bool expression, const std::ostream& errorMessage)
+    void macro_AY_ASSERT(const bool expression, const std::ostream& errorMessage)
     {
         if (!expression){
             std::ostringstream oss;
@@ -39,6 +36,14 @@ namespace {
     void macro_AY_LOG(const std::string&& message)
     {
         std::cout << "\n" << message;
+    }
+
+
+    void macro_AY_ERROR(const std::ostream& errorMessage)
+    {
+        std::ostringstream oss;
+        oss << "\n\n" << errorMessage.rdbuf();
+        throw std::runtime_error(oss.str());
     }
 
 
@@ -56,18 +61,4 @@ namespace {
         //std::cout << "\n" << m_title << " time: " << duration.count() << " microseconds\n" << std::endl;
     }
 
-
-    void macro_AY_ERROR(const std::string&& errorMessage)
-    {
-        throw std::runtime_error("\n\n" + errorMessage);
-    }
-
-
-    void macro_AY_ERROR_SS(const std::ostream& errorMessage)
-    {
-        std::ostringstream oss;
-        oss << "\n\n" << errorMessage.rdbuf();
-        throw std::runtime_error(oss.str());
-    }
-
-}
+} // namespace Ayla::Core::Macros

--- a/src/Ayla/Core/DebugMacros.h
+++ b/src/Ayla/Core/DebugMacros.h
@@ -4,31 +4,40 @@
 
 #pragma once
 
-
 #include "Ayla/aypch.h"
 
-// TODO: Add the macros here and rename core to something else that is more fitting
+
+/** Outputs the message to the console with a time stamp. */
+#define AY_TRACE(title) Ayla::Core::Macros::macro_AY_TRACE(title)
+
+/** Asserts a conditional. Throws an error if the conditional isn't true and outputs a message (that can come in the form of an ostream) to console. */
+#define AY_ASSERT(expression, errorMessage) { std::stringstream ss; Ayla::Core::Macros::macro_AY_ASSERT(expression, ss << errorMessage); }
+
+/** A simple log to console that standardizes which side of the string the new line character is on. */
+#define AY_LOG(message) Ayla::Core::Macros::macro_AY_LOG(message)
+
+/** Throws an error with a message outputted to the console. */
+#define AY_ERROR(errorMessage) { std::stringstream ss; Ayla::Core::Macros::macro_AY_ERROR(ss << errorMessage); }
+
+/** Profiles a scope and outputs the time to the console. */
+#define AY_PROFILE_SCOPE(title) Ayla::Core::Macros::AY_PROFILER(title)
+
 
 /** Macro Land */
-namespace
+namespace Ayla::Core::Macros
 {
-    /** Outputs the message to the console with a time stamp. */
+
+    /** Outputs the message to the console with a time stamp [hr:min:sec:ms]. */
     void macro_AY_TRACE(const std::string&& title);
 
-    /** Asserts a conditional. Throws an error if the conditional isn't true and outputs a message to console. */
-    void macro_AY_ASSERT(const bool expression, const std::string&& errorMessage);
-
     /** Asserts a conditional. Throws an error if the conditional isn't true and outputs a message (that can come in the form of an ostream) to console. */
-    void macro_AY_ASSERT_SS(const bool expression, const std::ostream& errorMessage);
+    void macro_AY_ASSERT(const bool expression, const std::ostream& errorMessage);
 
     /** A simple log to console that standardizes which side of the string the new line character is on. */
     void macro_AY_LOG(const std::string&& message);
 
-    /** Throws an error with a message outputted to the console. */
-    void macro_AY_ERROR(const std::string&& message);
-
     /** Throws an error with a message (that can come in the form of an ostream) outputted to the console. */
-    void macro_AY_ERROR_SS(bool expression, const std::ostream& errorMessage);
+    void macro_AY_ERROR(const std::ostream& errorMessage);
 
     /** Profiles a scope and outputs the time to the console. */
     class AY_PROFILER {
@@ -41,26 +50,5 @@ namespace
         std::string m_title;
     };
 
-}
-
-/** Outputs the message to the console with a time stamp. */
-#define AY_TRACE(title) macro_AY_TRACE(title)
-
-/** Asserts a conditional. Throws an error if the conditional isn't true and outputs a message to console. */
-#define AY_ASSERT(expression, errorMessage) macro_AY_ASSERT(expression, errorMessage)
-
-/** Asserts a conditional. Throws an error if the conditional isn't true and outputs a message (that can come in the form of an ostream) to console. */
-#define AY_ASSERT_SS(expression, errorMessage) { std::stringstream ss; macro_AY_ASSERT_SS(expression, ss << errorMessage); } // Stringstream alternative assert, so you can use an ostream for the debug message
-
-/** A simple log to console that standardizes which side of the string the new line character is on. */
-#define AY_LOG(message) macro_AY_LOG(message)
-
-/** Profiles a scope and outputs the time to the console. */
-#define AY_PROFILE_SCOPE(title) AY_PROFILER(title)
-
-/** Throws an error with a message outputted to the console. */
-#define AY_ERROR(errorMessage) macro_AY_ERROR(errorMessage)
-
-/** Throws an error with a message (that can come in the form of an ostream) outputted to the console. */
-#define AY_ERROR_SS(errorMessage) { std::stringstream ss; macro_AY_ERROR_SS(ss << errorMessage); } // Stringstream alternative assert, so you can use an ostream for the debug message
+} // namespace Ayla::Core::Macros
 

--- a/src/Ayla/Core/EntryPoint.h
+++ b/src/Ayla/Core/EntryPoint.h
@@ -8,7 +8,7 @@
 
 int main(int argc, char *argv[])
 {
-#ifdef UNKNOWN_PLATFORM
+#ifdef AYLA_PLATFORM_UNKNOWN
     AY_ERROR("[Ayla] Core/EntryPoint.h: Unsupported/Unknown Platform!");
 #endif
 

--- a/src/Ayla/Core/Time/Clock.cpp
+++ b/src/Ayla/Core/Time/Clock.cpp
@@ -65,7 +65,7 @@ namespace Ayla::Core::Time
                 }
                 catch(std::exception& exception)
                 {
-                    AY_ERROR_SS("Timer callback function caused an error of : " << exception.what());
+                    AY_ERROR("Timer callback function caused an error of : " << exception.what());
                 }
             }
         }

--- a/src/Ayla/Window/Platform/Generic/GenericWindow.cpp
+++ b/src/Ayla/Window/Platform/Generic/GenericWindow.cpp
@@ -17,7 +17,7 @@ namespace Ayla::Windows {
 
     void GlfwErrorCallback(int error, const char* description)
     {
-        AY_ERROR_SS(description << error);
+        AY_ERROR(description << error);
     }
 
 

--- a/src/Ayla/aypch.h
+++ b/src/Ayla/aypch.h
@@ -25,10 +25,10 @@
 #include <vector>
 
 // Other Stuff
-#include "Ayla/Core/Core.h"
+#include "Ayla/Core/CoreDefinitions.h"
 #include "Ayla/Core/DebugMacros.h"
 
 
 #ifdef AYLA_PLATFORM_WINDOWS
-//#include <Windows.h> ///< Windows specific includes
+    //#include <Windows.h> ///< Windows specific includes
 #endif


### PR DESCRIPTION
- Refactored definitions and implementation of debug macros
- Refactored error handling in debug macros to use new AY_ERROR macro
- Renamed platform names in platform definitions

In this commit, we've optimized and cleaned up the debug macro implementation, and improved the error handling by utilizing a newly defined AY_ERROR macro. All includes of "Core.h" have been updated to "CoreDefinitions.h" to reflect the filename change. Additionally, the definitions of platform identifiers have been refactored for clarity. This commit message was generated by AI.